### PR TITLE
Late jsonify with complete output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ docs/_build/
 
 # PyBuilder
 target/
+
+trace.out

--- a/pytracing/pytracing.py
+++ b/pytracing/pytracing.py
@@ -31,9 +31,11 @@ class TraceWriter(threading.Thread):
     self.output = output_stream
 
   def run(self):
+    self.output.write('[')
     while not self.terminator.is_set():
       item = self.input.get()
-      self.output.write(item)
+      self.output.write(json.dumps(item) + ',\n')
+    self.output.write('{}]')    # empty {} so the final entry doesn't end with a comma
 
 
 class TraceProfiler(object):
@@ -72,45 +74,44 @@ class TraceProfiler(object):
 
   def install(self):
     """Install the trace function and open the JSON output stream."""
-    self._open_collection()            # Open the JSON output.
-    self.writer.start()                # Start the writer thread.
-    sys.setprofile(self.tracer)        # Set the trace/profile function.
+    # self._open_collection()  # Open the JSON output.
+    self.writer.start()  # Start the writer thread.
+    sys.setprofile(self.tracer)  # Set the trace/profile function.
     threading.setprofile(self.tracer)  # Set the trace/profile function for threads.
 
   def shutdown(self):
-    sys.setprofile(None)               # Clear the trace/profile function.
-    threading.setprofile(None)         # Clear the trace/profile function for threads.
-    self._close_collection()           # Close the JSON output.
-    self.terminator.set()              # Stop the writer thread.
-    self.writer.join()                 # Join the writer thread.
+    sys.setprofile(None)  # Clear the trace/profile function.
+    threading.setprofile(None)  # Clear the trace/profile function for threads.
+    # self._close_collection()  # Close the JSON output.
+    self.terminator.set()  # Stop the writer thread.
+    self.writer.join()  # Join the writer thread.
 
   def _open_collection(self):
     """Write the opening of a JSON array to the output."""
-    self.queue.put('[\n')
+    self.queue.put('[')
 
   def _close_collection(self):
     """Write the closing of a JSON array to the output."""
-    self.queue.put('{}\n]\n')
+    self.queue.put('{}]')
 
   def fire_event(self, event_type, func_name, func_filename, func_line_no,
                  caller_filename, caller_line_no):
     """Write a trace event to the output stream."""
     timestamp = to_microseconds(self.clock())
     # https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
-    event = json.dumps(
-              dict(
-                name=func_name,               # Event Name.
-                cat=func_filename,            # Event Category.
-                tid=self.thread_id,           # Thread ID.
-                ph=self.TYPES[event_type],    # Event Type.
-                pid=self.pid,                 # Process ID.
-                ts=timestamp,                 # Timestamp.
-                args=dict(
-                  function=':'.join([str(x) for x in (func_filename, func_line_no, func_name)]),
-                  caller=':'.join([str(x) for x in (caller_filename, caller_line_no)]),
-                )
-              )
-            ) + ',\n'
+
+    event = dict(
+      name=func_name,  # Event Name.
+      cat=func_filename,  # Event Category.
+      tid=self.thread_id,  # Thread ID.
+      ph=self.TYPES[event_type],  # Event Type.
+      pid=self.pid,  # Process ID.
+      ts=timestamp,  # Timestamp.
+      args=dict(
+        function=':'.join([str(x) for x in (func_filename, func_line_no, func_name)]),
+        caller=':'.join([str(x) for x in (caller_filename, caller_line_no)]),
+      )
+    )
     self.queue.put(event)
 
   def tracer(self, frame, event_type, arg):
@@ -126,4 +127,4 @@ class TraceProfiler(object):
           caller_line_no=frame.f_back.f_lineno,
         )
     except Exception:
-      pass     # Don't disturb execution if we can't log the trace.
+      pass  # Don't disturb execution if we can't log the trace.

--- a/test_pytracing.py
+++ b/test_pytracing.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import io
+import json
 import time
 
 from pytracing import TraceProfiler
@@ -22,8 +23,8 @@ def function_b(x):
 
 
 def main():
-  function_a(5)
-  function_b(15)
+  function_a(1)
+  function_b(1)
 
 
 if __name__ == '__main__':
@@ -33,3 +34,7 @@ if __name__ == '__main__':
     main()
     tp.shutdown()
     print('wrote trace.out')
+
+  with io.open('./trace.out', encoding='utf-8') as fh:
+    json.load(fh)
+

--- a/test_pytracing.py
+++ b/test_pytracing.py
@@ -24,7 +24,7 @@ def function_b(x):
 
 def main():
   function_a(1)
-  function_b(1)
+  function_b(2)
 
 
 if __name__ == '__main__':
@@ -35,6 +35,7 @@ if __name__ == '__main__':
     tp.shutdown()
     print('wrote trace.out')
 
+  # ensure the output is at least valid JSON
   with io.open('./trace.out', encoding='utf-8') as fh:
     json.load(fh)
 


### PR DESCRIPTION
- Run the JSON `dumps` in the writer thread rather than in the profiling thread. In my anecdotal example this increases overall profiled script runtime performance by ~30%

- Don't stop the writer thread until it's been signaled _and_ the queue is empty. Otherwise output may be truncated prematurely. This is the source of the "Did not finish" events, as well as some that are just missing.

- Ensure the output is valid JSON in the test