### PR TITLE
fixed bytes type error for python3

### DIFF
--- a/pytracing/pytracing.py
+++ b/pytracing/pytracing.py
@@ -32,17 +32,17 @@ class TraceWriter(threading.Thread):
 
   def _open_collection(self):
     """Write the opening of a JSON array to the output."""
-    self.output.write('[')
+    self.output.write(b'[')
 
   def _close_collection(self):
     """Write the closing of a JSON array to the output."""
-    self.output.write('{}]')  # empty {} so the final entry doesn't end with a comma
+    self.output.write(b'{}]')  # empty {} so the final entry doesn't end with a comma
 
   def run(self):
     self._open_collection()
     while not self.terminator.is_set() or not self.input.empty():
       item = self.input.get()
-      self.output.write(json.dumps(item) + ',\n')
+      self.output.write((json.dumps(item) + ',\n').encode('ascii'))
     self._close_collection()
 
 


### PR DESCRIPTION
Python3 needs the argument for file.write to be bytes.